### PR TITLE
bucket strftime

### DIFF
--- a/aggrec/aggregates.py
+++ b/aggrec/aggregates.py
@@ -249,7 +249,7 @@ Derived components MUST NOT be included in the signature input.
     aggregate_id = ObjectId()
     location = f"/api/v1/aggregates/{aggregate_id}"
 
-    s3_bucket = request.app.settings.s3.bucket
+    s3_bucket = request.app.settings.s3.get_bucket_name()
 
     if aggregate_interval:
         period = pendulum.parse(aggregate_interval)

--- a/aggrec/settings.py
+++ b/aggrec/settings.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timezone
 from typing import Annotated, Tuple, Type
 
 from pydantic import AnyHttpUrl, BaseModel, DirectoryPath, Field, UrlConstraints
@@ -40,6 +41,9 @@ class S3(BaseModel):
     secret_access_key: str | None = None
     bucket: str = Field(default="aggrec")
     create_bucket: bool = False
+
+    def get_bucket_name(self) -> str:
+        return datetime.now(tz=timezone.utc).strftime(self.bucket)
 
 
 class Settings(BaseSettings):


### PR DESCRIPTION
As buckets tends to full over time we might need to distribute objects among multiple bucket. This PR uses the S3 bucket name as a template for strftime, e.g. "aggregates-%Y".