### PR TITLE
Handle duplicate aggregates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,10 @@ test-client: test-client-p256 test-client-ed25519
 test-client-p256: test-private-p256.pem
 	openssl rand 1024 > random.bin
 	poetry run aggrec_client --http-key-id test-p256 --http-key-file $< random.bin
+	openssl rand 1024 > random.bin
+	poetry run aggrec_client --http-key-id test-p256 --http-key-file $< random.bin
+	poetry run aggrec_client --http-key-id test-p256 --http-key-file $< random.bin
+	poetry run aggrec_client --http-key-id test-p256 --http-key-file $< random.bin
 
 test-client-ed25519: test-private-ed25519.pem
 	openssl rand 1024 > random.bin

--- a/aggrec/db_models.py
+++ b/aggrec/db_models.py
@@ -9,10 +9,7 @@ class AggregateType(Enum):
 
 
 class AggregateMetadata(Document):
-    meta = {
-        "collection": "aggregates",
-        "indexes": [{"fields": ["content_digest"], "unique": True, "sparse": True}],
-    }
+    meta = {"collection": "aggregates"}
 
     creator = StringField()
 
@@ -22,7 +19,7 @@ class AggregateMetadata(Document):
 
     content_type = StringField()
     content_length = IntField()
-    content_digest = StringField()
+    content_digest = StringField(unique=True, sparse=True)
 
     s3_bucket = StringField()
     s3_object_key = StringField()

--- a/aggrec/db_models.py
+++ b/aggrec/db_models.py
@@ -9,7 +9,10 @@ class AggregateType(Enum):
 
 
 class AggregateMetadata(Document):
-    meta = {"collection": "aggregates"}
+    meta = {
+        "collection": "aggregates",
+        "indexes": [{"fields": ["content_digest"], "unique": True, "sparse": True}],
+    }
 
     creator = StringField()
 
@@ -19,6 +22,7 @@ class AggregateMetadata(Document):
 
     content_type = StringField()
     content_length = IntField()
+    content_digest = StringField()
 
     s3_bucket = StringField()
     s3_object_key = StringField()


### PR DESCRIPTION
Detect, log and handle duplicate aggregates using `content-digest` header and return original metadata if we receive the same aggregate a 2nd time.
