### PR TITLE
Add support for NATS

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ server =  "mongodb://localhost/aggregates"
 broker = "mqtt://localhost"
 topic = "aggregates"
 
+[nats]
+servers = ["nats://localhost:4222"]
+subject = "aggregates"
+
 [otlp]
 spans_endpoint = "http://localhost:4317"
 metrics_endpoint = "http://localhost:4317"

--- a/aggrec.toml
+++ b/aggrec.toml
@@ -18,6 +18,10 @@ server =  "mongodb://localhost/aggregates"
 broker = "mqtt://localhost"
 topic = "aggregates"
 
+[nats]
+servers = ["nats://localhost:4222"]
+subject = "aggregates"
+
 [otlp]
 spans_endpoint = "http://localhost:4317"
 metrics_endpoint = "http://localhost:4317"

--- a/aggrec/server.py
+++ b/aggrec/server.py
@@ -91,12 +91,16 @@ class AggrecServer(FastAPI):
         assert settings is not None
         servers = [str(server) for server in settings.servers]
         self.logger.debug("Connecting to NATS servers %s", servers)
-        client = await nats.connect(
-            servers=servers,
-            name=settings.name,
-            user=settings.user,
-            password=settings.password,
-        )
+        try:
+            client = await nats.connect(
+                servers=servers,
+                name=settings.name,
+                user=settings.user,
+                password=settings.password,
+            )
+        except nats.errors.Error as e:
+            self.logger.error("Failed to connect to NATS servers: %s", str(e))
+            raise
         self.logger.debug("Created NATS client %s", client)
         return client
 

--- a/aggrec/settings.py
+++ b/aggrec/settings.py
@@ -34,7 +34,7 @@ class MqttSettings(BaseModel):
 
 
 class NatsSettings(BaseModel):
-    servers: list[NatsUrl] = Field(default="nats://localhost:4222")
+    servers: list[NatsUrl] = Field(default=["nats://localhost:4222"])
     name: str = Field(default="aggrec")
     user: str | None = None
     password: str | None = None

--- a/aggrec/settings.py
+++ b/aggrec/settings.py
@@ -13,6 +13,11 @@ MqttUrl = Annotated[
     UrlConstraints(allowed_schemes=["mqtt", "mqtts"], default_port=1883, host_required=True),
 ]
 
+NatsUrl = Annotated[
+    Url,
+    UrlConstraints(allowed_schemes=["nats", "tls"], default_port=4222, host_required=True),
+]
+
 MongodbUrl = Annotated[
     Url,
     UrlConstraints(allowed_schemes=["mongodb"], default_port=27017, host_required=True),
@@ -24,6 +29,16 @@ class MqttSettings(BaseModel):
     username: str | None = None
     password: str | None = None
     topic: str = Field(default="aggregates")
+    reconnect_interval: int = Field(default=5)
+    queue_size: int = Field(default=1024)
+
+
+class NatsSettings(BaseModel):
+    servers: list[NatsUrl] = Field(default="nats://localhost:4222")
+    name: str = Field(default="aggrec")
+    user: str | None = None
+    password: str | None = None
+    subject: str = Field(default="aggregates")
     reconnect_interval: int = Field(default=5)
     queue_size: int = Field(default=1024)
 
@@ -48,7 +63,8 @@ class Settings(BaseSettings):
     metadata_base_url: AnyHttpUrl = Field(default="http://127.0.0.1")
     clients_database: str = Field(default="clients")
     s3: S3 = Field(default=S3())
-    mqtt: MqttSettings = Field(default=MqttSettings())
+    mqtt: MqttSettings | None = None
+    nats: NatsSettings | None = None
     mongodb: MongoDB = Field(default=MongoDB())
     otlp: OtlpSettings | None = None
     key_cache: KeyCacheSettings | None = None

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -40,6 +40,13 @@ services:
     configs:
       - source: mosquitto.conf
         target: /mosquitto/config/mosquitto.conf
+  nats:
+    image: nats:latest
+    restart: unless-stopped
+    command: "--jetstream --http_port 8222"
+    ports:
+      - 127.0.0.1:4222:4222/tcp
+      - 127.0.0.1:8222:8222/tcp
   otel-collector:
     image: otel/opentelemetry-collector:latest
     command: ["--config=/etc/otel-collector-config.yaml"]

--- a/poetry.lock
+++ b/poetry.lock
@@ -1290,6 +1290,22 @@ files = [
 ]
 
 [[package]]
+name = "nats-py"
+version = "2.9.0"
+description = "NATS client for Python"
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+files = [
+    {file = "nats_py-2.9.0.tar.gz", hash = "sha256:01886eb9e0a87f0ec630652cf1fae65d2a8556378a609bc6cc07d2ea60c8d0dd"},
+]
+
+[package.extras]
+aiohttp = ["aiohttp"]
+fast-parse = ["fast-mail-parser"]
+nkeys = ["nkeys"]
+
+[[package]]
 name = "objsize"
 version = "0.7.0"
 description = "Traversal over Python's objects subtree and calculate the total size of the subtree in bytes (deep size)."
@@ -2586,4 +2602,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12"
-content-hash = "ecbe98a670d84a03587e1aaaf408e39d2a06f507077c8dd44f5f0a484b892641"
+content-hash = "64d52ce75901977e1a78ca25797d9ff8071572fe60fbd89e11ee2c27f3b60948"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aggrec"
-version = "1.1.0.dev3"
+version = "1.1.0.dev4"
 description = "DNS TAPIR Aggregate Receiver"
 authors = ["Jakob Schlyter <jakob@kirei.se>"]
 readme = "README.md"
@@ -26,6 +26,7 @@ http-sf = "^1.0.2"
 redis = "^5.1.1"
 aiobotocore = ">=2.19.0"
 aniso8601 = "^10.0.0"
+nats-py = "^2.9.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.2.0"


### PR DESCRIPTION
Aggrec should be able to post new aggregate messages to NATS in addition to MQTT. This PR adds basic support for publishing to NATS, while cleaning up some MQTT code while at it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Integrated NATS messaging support, enhancing message queuing and error handling.
  - Added new configuration options for NATS in the documentation and configuration files.
  - Introduced a dedicated NATS service in the container setup to streamline deployment.
  - Updated project dependencies and bumped the version to ensure compatibility with the enhanced messaging features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->