### PR TITLE
Allow configuration override with environment

### DIFF
--- a/aggrec/server.py
+++ b/aggrec/server.py
@@ -231,7 +231,8 @@ def main() -> None:
 
     logger.info("Starting Aggregate Receiver version %s", __verbose_version__)
 
-    app = AggrecServer(settings=Settings())
+    settings = Settings()
+    app = AggrecServer(settings=settings)
 
     uvicorn.run(
         app,

--- a/aggrec/settings.py
+++ b/aggrec/settings.py
@@ -12,7 +12,7 @@ from dnstapir.key_cache import KeyCacheSettings
 from dnstapir.opentelemetry import OtlpSettings
 
 CONFIG_FILE = os.environ.get("AGGREC_CONFIG", "aggrec.toml")
-ENV_PREFIX = "DNSTAPIR_AGGREC_"
+ENV_PREFIX = "DNSTAPIR_AGGREC__"
 
 MqttUrl = Annotated[
     Url,

--- a/aggrec/settings.py
+++ b/aggrec/settings.py
@@ -12,7 +12,7 @@ from dnstapir.key_cache import KeyCacheSettings
 from dnstapir.opentelemetry import OtlpSettings
 
 CONFIG_FILE = os.environ.get("AGGREC_CONFIG", "aggrec.toml")
-ENV_PREFIX = "DNSTAPIR_AGGREC__"
+ENV_PREFIX = "AGGREC_"
 
 MqttUrl = Annotated[
     Url,


### PR DESCRIPTION
can be overridden using `DNSTAPIR_AGGREC__MONGODB__SERVER=mongodb://username:password@xyzzy/aggrec`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the separation of configuration setup from server instantiation for better clarity.

- **New Features**
  - Added support for environment variable configuration with a specific prefix, allowing environment variables to override or supplement TOML configuration files. This enables more flexible and dynamic configuration management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->